### PR TITLE
Simplify `Nonoid.complex_generate` method

### DIFF
--- a/lib/nanoid.rb
+++ b/lib/nanoid.rb
@@ -25,21 +25,18 @@ module Nanoid
     step = (1.6 * mask * size / alphabet_size).ceil
 
     id = ''.dup
-    catch :computed do
-      loop do
-        bytes = random_bytes(size)
-        (0...step).each do |i|
-          byte = bytes[i] & mask
-          character = byte && alphabet[byte]
-          if character
-            id << character
-            throw :computed if id.size == size
-          end
+
+    loop do
+      bytes = random_bytes(size)
+      (0...step).each do |idx|
+        byte = bytes[idx] & mask
+        character = byte && alphabet[byte]
+        if character
+          id << character
+          return id if id.size == size
         end
       end
     end
-
-    id
   end
 
   def self.random_bytes(size)


### PR DESCRIPTION
Hi!

It is a small enhancement of complex code construction and it brings a little perfomance improvement as well:

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('original') do
    100_000.times do
      Nanoid.complex_generate(size: 21, alphabet: Nanoid::SAFE_ALPHABET)
    end
  end

  x.report('patch') do
    100_000.times do
      Nanoid.complex_generate_patch(size: 21, alphabet: Nanoid::SAFE_ALPHABET)
    end
  end

  x.compare!
end
```

Output:
```
Warming up --------------------------------------
            original     1.000  i/100ms
               patch     1.000  i/100ms
Calculating -------------------------------------
            original      0.967  (± 0.0%) i/s -      5.000  in   5.169805s
               patch      1.025  (± 0.0%) i/s -      6.000  in   5.854103s

Comparison:
               patch:        1.0 i/s
            original:        1.0 i/s - 1.06x  slower
```

Best regards!