### PR TITLE
String is not frozen by default

### DIFF
--- a/lib/nanoid.rb
+++ b/lib/nanoid.rb
@@ -1,9 +1,7 @@
-# frozen_string_literal: true
-
 require 'securerandom'
 
 module Nanoid
-  SAFE_ALPHABET = '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  SAFE_ALPHABET = '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.freeze
 
   def self.generate(size: 21, alphabet: SAFE_ALPHABET, non_secure: false)
     return non_secure_generate(size: size, alphabet: alphabet) if non_secure
@@ -18,7 +16,7 @@ module Nanoid
   def self.simple_generate(size:)
     bytes = random_bytes(size)
 
-    (0...size).reduce(''.dup) do |acc, i|
+    (0...size).reduce('') do |acc, i|
       acc << SAFE_ALPHABET[bytes[i] & 63]
     end
   end
@@ -28,7 +26,7 @@ module Nanoid
     mask = (2 << Math.log(alphabet_size - 1) / Math.log(2)) - 1
     step = (1.6 * mask * size / alphabet_size).ceil
 
-    id = ''.dup
+    id = ''
 
     loop do
       bytes = random_bytes(size)
@@ -46,7 +44,7 @@ module Nanoid
   def self.non_secure_generate(size:, alphabet:)
     alphabet_size = alphabet.size
 
-    id = ''.dup
+    id = ''
 
     size.times do
       id << alphabet[(Random.rand * alphabet_size).floor]


### PR DESCRIPTION
This module depends on string concatenation so string literal should not be frozen.
This change makes code slightly simple by removing multiple `dup`s.